### PR TITLE
Updated Copy-CMTaskSequence Link

### DIFF
--- a/sccm-ps/ConfigurationManager/Copy-CMTaskSequence.md
+++ b/sccm-ps/ConfigurationManager/Copy-CMTaskSequence.md
@@ -181,7 +181,7 @@ Accept wildcard characters: False
 
 ## RELATED LINKS
 
-[New-CMTaskSequence](Get-CMTaskSequence.md)
+[New-CMTaskSequence](New-CMTaskSequence.md)
 [Get-CMTaskSequence](Get-CMTaskSequence.md)
 [Set-CMTaskSequence](Set-CMTaskSequence.md)
 [Copy-CMTaskSequence](Copy-CMTaskSequence.md)


### PR DESCRIPTION
Link for New-CMTaskSequence referenced Get-CMTaskSequence instead. 
Looked like a typo.