### PR TITLE
Updated New-CMTaskSequence Link

### DIFF
--- a/sccm-ps/ConfigurationManager/Set-CMTaskSequence.md
+++ b/sccm-ps/ConfigurationManager/Set-CMTaskSequence.md
@@ -536,7 +536,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[New-CMTaskSequence](Get-CMTaskSequence.md)
+[New-CMTaskSequence](New-CMTaskSequence.md)
 [Get-CMTaskSequence](Get-CMTaskSequence.md)
 [Set-CMTaskSequence](Set-CMTaskSequence.md)
 [Copy-CMTaskSequence](Copy-CMTaskSequence.md)


### PR DESCRIPTION
Link for New-CMTaskSequence referenced Get-CMTaskSequence instead. 
Looked like a typo.