### PR TITLE
Updated New-CMTaskSequence Link

### DIFF
--- a/sccm-ps/ConfigurationManager/Import-CMTaskSequence.md
+++ b/sccm-ps/ConfigurationManager/Import-CMTaskSequence.md
@@ -162,7 +162,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[New-CMTaskSequence](Get-CMTaskSequence.md)
+[New-CMTaskSequence](Net-CMTaskSequence.md)
 
 [Get-CMTaskSequence](Get-CMTaskSequence.md)
 


### PR DESCRIPTION
Link for New-CMTaskSequence referenced Get-CMTaskSequence instead. 
Looked like a typo.