### PR TITLE
Remove cmboundarygroup

### DIFF
--- a/sccm-ps/ConfigurationManager/Get-CMBoundaryGroup.md
+++ b/sccm-ps/ConfigurationManager/Get-CMBoundaryGroup.md
@@ -48,28 +48,11 @@ Name:               BGroup01
 SiteSystemCount:    0
 ```
 
-This command gets a boundary group that is specified by the identifier 1600231.  
+This command gets a boundary group that is specified by the identifier 1600231.
 
-### Example 2: Get a boundary group by name
+### Example 2: Get multiple boundary groups that are specified by name
 ```
-PS C:\> Get-CMBoundaryGroup -Name "BGroup01"
-CreatedBy:          Contoso\ENarvaez
-CreatedOn           5/17/2012 07:13:02 AM
-DefaultSiteCode: 
-Description: 
-GroupID:            1600231
-MemberCount:        80
-ModifiedBy:         
-ModifiedOn:         
-Name:               BGroup01 
-SiteSystemCount:    0
-```
-
-This command gets the boundary group "BGroup01".
-
-### Example 3: Get multiple boundary groups using a wildcard
-```
-PS C:\> Get-CMBoundaryGroup -Name "BGroup0*"
+PS C:\> Get-CMBoundaryGroup -Name "BGroup01", "BGroup02", "BGroup03"
 CreatedBy:          Contoso\ENarvaez
 CreatedOn           5/17/2012 07:13:02 AM
 DefaultSiteCode: 
@@ -102,39 +85,9 @@ Name:               BGroup03
 SiteSystemCount:    0
 ```
 
-This command gets multiple boundary groups that match "BGroup0*".
+This command gets multiple boundary groups that are specified by the names BGroup01, BGroup02, and BGroup03.
 
 ## PARAMETERS
-
-### -Id
-Specifies an array of identifiers (IDs) for one or more boundary groups. This id is represented by the GroupID property of the object this cmdlet returns.
-
-```yaml
-Type: String[]
-Parameter Sets: SearchByIdMandatory
-Aliases: GroupId
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: True
-Accept wildcard characters: False
-```
-
-### -Name
-Specifies the name for a boundary group.
-
-```yaml
-Type: String
-Parameter Sets: SearchByName
-Aliases: 
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: True
-```
 
 ### -DisableWildcardHandling
 DisableWildcardHandling treats wildcard characters as literal character values. Cannot be combined with **ForceWildcardHandling**.
@@ -166,6 +119,35 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Id
+Specifies an array of identifiers (IDs) for one or more boundary groups.
+
+```yaml
+Type: String[]
+Parameter Sets: SearchByIdMandatory
+Aliases: GroupId
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Name
+Specifies the name for a boundary group.
+
+```yaml
+Type: String
+Parameter Sets: SearchByName
+Aliases: 
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### CommonParameters
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).

--- a/sccm-ps/ConfigurationManager/Get-CMBoundaryGroup.md
+++ b/sccm-ps/ConfigurationManager/Get-CMBoundaryGroup.md
@@ -48,11 +48,28 @@ Name:               BGroup01
 SiteSystemCount:    0
 ```
 
-This command gets a boundary group that is specified by the identifier 1600231.
+This command gets a boundary group that is specified by the identifier 1600231.  
 
-### Example 2: Get multiple boundary groups that are specified by name
+### Example 2: Get a boundary group by name
 ```
-PS C:\> Get-CMBoundaryGroup -Name "BGroup01", "BGroup02", "BGroup03"
+PS C:\> Get-CMBoundaryGroup -Name "BGroup01"
+CreatedBy:          Contoso\ENarvaez
+CreatedOn           5/17/2012 07:13:02 AM
+DefaultSiteCode: 
+Description: 
+GroupID:            1600231
+MemberCount:        80
+ModifiedBy:         
+ModifiedOn:         
+Name:               BGroup01 
+SiteSystemCount:    0
+```
+
+This command gets the boundary group "BGroup01".
+
+### Example 3: Get multiple boundary groups using a wildcard
+```
+PS C:\> Get-CMBoundaryGroup -Name "BGroup0*"
 CreatedBy:          Contoso\ENarvaez
 CreatedOn           5/17/2012 07:13:02 AM
 DefaultSiteCode: 
@@ -85,9 +102,39 @@ Name:               BGroup03
 SiteSystemCount:    0
 ```
 
-This command gets multiple boundary groups that are specified by the names BGroup01, BGroup02, and BGroup03.
+This command gets multiple boundary groups that match "BGroup0*".
 
 ## PARAMETERS
+
+### -Id
+Specifies an array of identifiers (IDs) for one or more boundary groups. This id is represented by the GroupID property of the object this cmdlet returns.
+
+```yaml
+Type: String[]
+Parameter Sets: SearchByIdMandatory
+Aliases: GroupId
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True
+Accept wildcard characters: False
+```
+
+### -Name
+Specifies the name for a boundary group.
+
+```yaml
+Type: String
+Parameter Sets: SearchByName
+Aliases: 
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
 
 ### -DisableWildcardHandling
 DisableWildcardHandling treats wildcard characters as literal character values. Cannot be combined with **ForceWildcardHandling**.
@@ -119,35 +166,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Id
-Specifies an array of identifiers (IDs) for one or more boundary groups.
-
-```yaml
-Type: String[]
-Parameter Sets: SearchByIdMandatory
-Aliases: GroupId
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Name
-Specifies the name for a boundary group.
-
-```yaml
-Type: String
-Parameter Sets: SearchByName
-Aliases: 
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
 
 ### CommonParameters
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).

--- a/sccm-ps/ConfigurationManager/Remove-CMBoundaryGroup.md
+++ b/sccm-ps/ConfigurationManager/Remove-CMBoundaryGroup.md
@@ -45,16 +45,62 @@ Because the *Force* parameter is not specified, you must confirm the action befo
 
 ### Example 2: Remove multiple boundary groups by using an InputObject
 ```
-PS C:\> $BoundaryObj = Get-CMBoundary -Name "BGroup01", "BGroup02", "BGroup03"
+PS C:\> $BoundaryObj = Get-CMBoundaryGroup -Name "BGroup0*"
 PS C:\> Remove-CMBoundary -InputObject $BoundaryObj
 ```
 
-The first command uses the **Get-CMBoundaryGroup** to get multiple boundary groups that are specified by their names, and stores this data into the $BoundaryObj variable.
+The first command uses the **Get-CMBoundaryGroup** to get multiple boundary groups that are specified by a wildcard name, and stores this data into the $BoundaryObj variable.
 
 The second command identifies and removes the boundaries that are specified by using the input object $BoundaryObj.
 Because the *Force* parameter is not specified, you must confirm the action before it is performed.
 
 ## PARAMETERS
+
+### -Id
+Specifies an array of identifiers (IDs) for one or more boundary groups.
+
+```yaml
+Type: String[]
+Parameter Sets: SearchByIdMandatory
+Aliases: GroupId
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InputObject
+Specifies an input object to this cmdlet.
+You can get the input object by using the [Get-CMBoundaryGroup](Get-CMBoundaryGroup.md) cmdlet.
+
+```yaml
+Type: IResultObject
+Parameter Sets: SearchByValueMandatory
+Aliases: 
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Name
+Specifies the name of a boundary group.
+
+```yaml
+Type: String
+Parameter Sets: SearchByNameMandatory
+Aliases: 
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -Confirm
 Prompts you for confirmation before running the cmdlet.
@@ -110,52 +156,6 @@ Parameter Sets: (All)
 Aliases: 
 
 Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Id
-Specifies an array of identifiers (IDs) for one or more boundary groups.
-
-```yaml
-Type: String[]
-Parameter Sets: SearchByIdMandatory
-Aliases: GroupId
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -InputObject
-Specifies an input object to this cmdlet.
-You can get the input object by using the [Get-CMBoundaryGroup](Get-CMBoundaryGroup.md) cmdlet.
-
-```yaml
-Type: IResultObject
-Parameter Sets: SearchByValueMandatory
-Aliases: 
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: True (ByValue)
-Accept wildcard characters: False
-```
-
-### -Name
-Specifies the name of a boundary group.
-
-```yaml
-Type: String
-Parameter Sets: SearchByNameMandatory
-Aliases: 
-
-Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False


### PR DESCRIPTION
Fixes #24 

Changes example to work correctly (Get-CMBoundaryGroup no longer accepts a string of names) and also corrects the typo/mistake in the example of using Get-CMBoundary instead of Get-CMBoundaryGroup).

Moved the InputObject, ID, and Name parameters to the top of the parameter list