### PR TITLE
Change PowerShell Example to use Dynamic Path

### DIFF
--- a/docs-conceptual/overview.md
+++ b/docs-conceptual/overview.md
@@ -74,7 +74,7 @@ Another method of connecting to Configuration Manager from your Windows PowerShe
 
     ```  PowerShell
     PS C:\>  
-    PS C:\> CD 'C:\Program Files (x86)\Microsoft Configuration Manager\AdminConsole\bin'  
+    PS C:\> cd $env:SMS_ADMIN_UI_PATH\..\
     PS C:\Program Files (x86)\Microsoft Configuration Manager\AdminConsole\bin> Import-Module .\ConfigurationManager.psd1  
     ```  
 


### PR DESCRIPTION
Updated changing the directory from the static path of the default console location to use the environment variable instead to account for environments where the console is not installed in the typical location or on the system disk.

#MMS2019Docathon