### PR TITLE
Added note about the maximum size of icons in applications

### DIFF
--- a/sccm-ps/ConfigurationManager/New-CMApplication.md
+++ b/sccm-ps/ConfigurationManager/New-CMApplication.md
@@ -127,8 +127,7 @@ Accept wildcard characters: False
 ```
 
 ### -IconLocationFile
-Specifies the location of the icon file.
-This is set to the single default language.
+Specifies the location of the icon file. This is set to the single default language. The size of the icon image cannot be greater than 512x512.
 
 ```yaml
 Type: String


### PR DESCRIPTION
Icons in applications cannot be greater than 512x512 but this is not called out in this document.  Users who try and use larger images will have the examples fail.  Added note that represents this.

#MMS2019Docathon 