### PR TITLE
Removed unused CollectionTypes

### DIFF
--- a/sccm-ps/ConfigurationManager/New-CMCollection.md
+++ b/sccm-ps/ConfigurationManager/New-CMCollection.md
@@ -59,12 +59,6 @@ This command gets the collection object named All Users and uses the pipeline op
 
 ### -CollectionType
 Specifies a type for the collection.
-Valid values are:
-
-- Root
-- User
-- Device
-- Unknown
 
 ```yaml
 Type: CollectionType


### PR DESCRIPTION
While UNKNOWN and ROOT are part of the available options, neither are actually available to call using this function (they both return errors as they're not valid collection types).  Further, we don't need a bulleted list of available options right above when we list what the accepted values are.

#MMS2019Docathon 