### PR TITLE
Fixed all references of 'a t s' to 'a TS'

### DIFF
--- a/sccm-ps/ConfigurationManager/Get-CMTSStepConditionFile.md
+++ b/sccm-ps/ConfigurationManager/Get-CMTSStepConditionFile.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # Get-CMTSStepConditionFile
 
 ## SYNOPSIS
-Gets a t s step condition file
+Gets a TS step condition file
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/Get-CMTSStepConditionFolder.md
+++ b/sccm-ps/ConfigurationManager/Get-CMTSStepConditionFolder.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # Get-CMTSStepConditionFolder
 
 ## SYNOPSIS
-Gets a t s step condition folder
+Gets a TS step condition folder
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/Get-CMTSStepConditionIfStatement.md
+++ b/sccm-ps/ConfigurationManager/Get-CMTSStepConditionIfStatement.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # Get-CMTSStepConditionIfStatement
 
 ## SYNOPSIS
-Gets a t s step condition if statement
+Gets a TS step condition if statement
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/Get-CMTSStepConditionOperatingSystem.md
+++ b/sccm-ps/ConfigurationManager/Get-CMTSStepConditionOperatingSystem.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # Get-CMTSStepConditionOperatingSystem
 
 ## SYNOPSIS
-Gets a t s step condition operating system
+Gets a TS step condition operating system
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/Get-CMTSStepConditionQueryWmi.md
+++ b/sccm-ps/ConfigurationManager/Get-CMTSStepConditionQueryWmi.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # Get-CMTSStepConditionQueryWmi
 
 ## SYNOPSIS
-Gets a t s step condition query wmi
+Gets a TS step condition query wmi
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/Get-CMTSStepConditionRegistry.md
+++ b/sccm-ps/ConfigurationManager/Get-CMTSStepConditionRegistry.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # Get-CMTSStepConditionRegistry
 
 ## SYNOPSIS
-Gets a t s step condition registry
+Gets a TS step condition registry
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/Get-CMTSStepConditionSoftware.md
+++ b/sccm-ps/ConfigurationManager/Get-CMTSStepConditionSoftware.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # Get-CMTSStepConditionSoftware
 
 ## SYNOPSIS
-Gets a t s step condition software
+Gets a TS step condition software
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/Get-CMTSStepConditionVariable.md
+++ b/sccm-ps/ConfigurationManager/Get-CMTSStepConditionVariable.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # Get-CMTSStepConditionVariable
 
 ## SYNOPSIS
-Gets a t s step condition variable
+Gets a TS step condition variable
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/Get-CMTSStepInstallApplication.md
+++ b/sccm-ps/ConfigurationManager/Get-CMTSStepInstallApplication.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # Get-CMTSStepInstallApplication
 
 ## SYNOPSIS
-Gets a t s step install application
+Gets a TS step install application
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/Get-CMTSStepInstallSoftware.md
+++ b/sccm-ps/ConfigurationManager/Get-CMTSStepInstallSoftware.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # Get-CMTSStepInstallSoftware
 
 ## SYNOPSIS
-Gets a t s step install software
+Gets a TS step install software
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/Get-CMTSStepInstallUpdate.md
+++ b/sccm-ps/ConfigurationManager/Get-CMTSStepInstallUpdate.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # Get-CMTSStepInstallUpdate
 
 ## SYNOPSIS
-Gets a t s step install update
+Gets a TS step install update
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/Get-CMTSStepPartitionDisk.md
+++ b/sccm-ps/ConfigurationManager/Get-CMTSStepPartitionDisk.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # Get-CMTSStepPartitionDisk
 
 ## SYNOPSIS
-Gets a t s step partition disk
+Gets a TS step partition disk
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/Get-CMTSStepReboot.md
+++ b/sccm-ps/ConfigurationManager/Get-CMTSStepReboot.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # Get-CMTSStepReboot
 
 ## SYNOPSIS
-Gets a t s step reboot
+Gets a TS step reboot
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/Get-CMTSStepRunCommandLine.md
+++ b/sccm-ps/ConfigurationManager/Get-CMTSStepRunCommandLine.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # Get-CMTSStepRunCommandLine
 
 ## SYNOPSIS
-Gets a t s step run command line
+Gets a TS step run command line
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/Get-CMTSStepRunPowerShellScript.md
+++ b/sccm-ps/ConfigurationManager/Get-CMTSStepRunPowerShellScript.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # Get-CMTSStepRunPowerShellScript
 
 ## SYNOPSIS
-Gets a t s step run power shell script
+Gets a TS step run power shell script
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/Get-CMTSStepSetVariable.md
+++ b/sccm-ps/ConfigurationManager/Get-CMTSStepSetVariable.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # Get-CMTSStepSetVariable
 
 ## SYNOPSIS
-Gets a t s step set variable
+Gets a TS step set variable
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/Get-CMTSStepSetupWindowsAndConfigMgr.md
+++ b/sccm-ps/ConfigurationManager/Get-CMTSStepSetupWindowsAndConfigMgr.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # Get-CMTSStepSetupWindowsAndConfigMgr
 
 ## SYNOPSIS
-Gets a t s step setup windows and config mgr
+Gets a TS step setup windows and config mgr
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/New-CMTSPartitionSetting.md
+++ b/sccm-ps/ConfigurationManager/New-CMTSPartitionSetting.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # New-CMTSPartitionSetting
 
 ## SYNOPSIS
-Creates a t s partition setting
+Creates a TS partition setting
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/New-CMTSStepConditionFile.md
+++ b/sccm-ps/ConfigurationManager/New-CMTSStepConditionFile.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # New-CMTSStepConditionFile
 
 ## SYNOPSIS
-Creates a t s step condition file
+Creates a TS step condition file
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/New-CMTSStepConditionFolder.md
+++ b/sccm-ps/ConfigurationManager/New-CMTSStepConditionFolder.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # New-CMTSStepConditionFolder
 
 ## SYNOPSIS
-Creates a t s step condition folder
+Creates a TS step condition folder
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/New-CMTSStepConditionIfStatement.md
+++ b/sccm-ps/ConfigurationManager/New-CMTSStepConditionIfStatement.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # New-CMTSStepConditionIfStatement
 
 ## SYNOPSIS
-Creates a t s step condition if statement
+Creates a TS step condition if statement
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/New-CMTSStepConditionOperatingSystem.md
+++ b/sccm-ps/ConfigurationManager/New-CMTSStepConditionOperatingSystem.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # New-CMTSStepConditionOperatingSystem
 
 ## SYNOPSIS
-Creates a t s step condition operating system
+Creates a TS step condition operating system
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/New-CMTSStepConditionQueryWmi.md
+++ b/sccm-ps/ConfigurationManager/New-CMTSStepConditionQueryWmi.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # New-CMTSStepConditionQueryWmi
 
 ## SYNOPSIS
-Creates a t s step condition query wmi
+Creates a TS step condition query wmi
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/New-CMTSStepConditionRegistry.md
+++ b/sccm-ps/ConfigurationManager/New-CMTSStepConditionRegistry.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # New-CMTSStepConditionRegistry
 
 ## SYNOPSIS
-Creates a t s step condition registry
+Creates a TS step condition registry
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/New-CMTSStepConditionSoftware.md
+++ b/sccm-ps/ConfigurationManager/New-CMTSStepConditionSoftware.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # New-CMTSStepConditionSoftware
 
 ## SYNOPSIS
-Creates a t s step condition software
+Creates a TS step condition software
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/New-CMTSStepConditionVariable.md
+++ b/sccm-ps/ConfigurationManager/New-CMTSStepConditionVariable.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # New-CMTSStepConditionVariable
 
 ## SYNOPSIS
-Creates a t s step condition variable
+Creates a TS step condition variable
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/New-CMTSStepInstallApplication.md
+++ b/sccm-ps/ConfigurationManager/New-CMTSStepInstallApplication.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # New-CMTSStepInstallApplication
 
 ## SYNOPSIS
-Creates a t s step install application
+Creates a TS step install application
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/New-CMTSStepInstallSoftware.md
+++ b/sccm-ps/ConfigurationManager/New-CMTSStepInstallSoftware.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # New-CMTSStepInstallSoftware
 
 ## SYNOPSIS
-Creates a t s step install software
+Creates a TS step install software
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/New-CMTSStepInstallUpdate.md
+++ b/sccm-ps/ConfigurationManager/New-CMTSStepInstallUpdate.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # New-CMTSStepInstallUpdate
 
 ## SYNOPSIS
-Creates a t s step install update
+Creates a TS step install update
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/New-CMTSStepPartitionDisk.md
+++ b/sccm-ps/ConfigurationManager/New-CMTSStepPartitionDisk.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # New-CMTSStepPartitionDisk
 
 ## SYNOPSIS
-Creates a t s step partition disk
+Creates a TS step partition disk
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/New-CMTSStepReboot.md
+++ b/sccm-ps/ConfigurationManager/New-CMTSStepReboot.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # New-CMTSStepReboot
 
 ## SYNOPSIS
-Creates a t s step reboot
+Creates a TS step reboot
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/New-CMTSStepRunCommandLine.md
+++ b/sccm-ps/ConfigurationManager/New-CMTSStepRunCommandLine.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # New-CMTSStepRunCommandLine
 
 ## SYNOPSIS
-Creates a t s step run command line
+Creates a TS step run command line
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/New-CMTSStepRunPowerShellScript.md
+++ b/sccm-ps/ConfigurationManager/New-CMTSStepRunPowerShellScript.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # New-CMTSStepRunPowerShellScript
 
 ## SYNOPSIS
-Creates a t s step run power shell script
+Creates a TS step run power shell script
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/New-CMTSStepSetVariable.md
+++ b/sccm-ps/ConfigurationManager/New-CMTSStepSetVariable.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # New-CMTSStepSetVariable
 
 ## SYNOPSIS
-Creates a t s step set variable
+Creates a TS step set variable
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/New-CMTSStepSetupWindowsAndConfigMgr.md
+++ b/sccm-ps/ConfigurationManager/New-CMTSStepSetupWindowsAndConfigMgr.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # New-CMTSStepSetupWindowsAndConfigMgr
 
 ## SYNOPSIS
-Creates a t s step setup windows and config mgr
+Creates a TS step setup windows and config mgr
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/Remove-CMTSStepInstallApplication.md
+++ b/sccm-ps/ConfigurationManager/Remove-CMTSStepInstallApplication.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # Remove-CMTSStepInstallApplication
 
 ## SYNOPSIS
-Removes a t s step install application
+Removes a TS step install application
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/Remove-CMTSStepInstallSoftware.md
+++ b/sccm-ps/ConfigurationManager/Remove-CMTSStepInstallSoftware.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # Remove-CMTSStepInstallSoftware
 
 ## SYNOPSIS
-Removes a t s step install software
+Removes a TS step install software
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/Remove-CMTSStepInstallUpdate.md
+++ b/sccm-ps/ConfigurationManager/Remove-CMTSStepInstallUpdate.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # Remove-CMTSStepInstallUpdate
 
 ## SYNOPSIS
-Removes a t s step install update
+Removes a TS step install update
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/Remove-CMTSStepPartitionDisk.md
+++ b/sccm-ps/ConfigurationManager/Remove-CMTSStepPartitionDisk.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # Remove-CMTSStepPartitionDisk
 
 ## SYNOPSIS
-Removes a t s step partition disk
+Removes a TS step partition disk
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/Remove-CMTSStepReboot.md
+++ b/sccm-ps/ConfigurationManager/Remove-CMTSStepReboot.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # Remove-CMTSStepReboot
 
 ## SYNOPSIS
-Removes a t s step reboot
+Removes a TS step reboot
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/Remove-CMTSStepRunCommandLine.md
+++ b/sccm-ps/ConfigurationManager/Remove-CMTSStepRunCommandLine.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # Remove-CMTSStepRunCommandLine
 
 ## SYNOPSIS
-Removes a t s step run command line
+Removes a TS step run command line
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/Remove-CMTSStepRunPowerShellScript.md
+++ b/sccm-ps/ConfigurationManager/Remove-CMTSStepRunPowerShellScript.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # Remove-CMTSStepRunPowerShellScript
 
 ## SYNOPSIS
-Removes a t s step run power shell script
+Removes a TS step run power shell script
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/Remove-CMTSStepSetVariable.md
+++ b/sccm-ps/ConfigurationManager/Remove-CMTSStepSetVariable.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # Remove-CMTSStepSetVariable
 
 ## SYNOPSIS
-Removes a t s step set variable
+Removes a TS step set variable
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/Remove-CMTSStepSetupWindowsAndConfigMgr.md
+++ b/sccm-ps/ConfigurationManager/Remove-CMTSStepSetupWindowsAndConfigMgr.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # Remove-CMTSStepSetupWindowsAndConfigMgr
 
 ## SYNOPSIS
-Removes a t s step setup windows and config mgr
+Removes a TS step setup windows and config mgr
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/Set-CMTSStepInstallApplication.md
+++ b/sccm-ps/ConfigurationManager/Set-CMTSStepInstallApplication.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # Set-CMTSStepInstallApplication
 
 ## SYNOPSIS
-Sets a t s step install application
+Sets a TS step install application
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/Set-CMTSStepInstallSoftware.md
+++ b/sccm-ps/ConfigurationManager/Set-CMTSStepInstallSoftware.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # Set-CMTSStepInstallSoftware
 
 ## SYNOPSIS
-Sets a t s step install software
+Sets a TS step install software
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/Set-CMTSStepInstallUpdate.md
+++ b/sccm-ps/ConfigurationManager/Set-CMTSStepInstallUpdate.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # Set-CMTSStepInstallUpdate
 
 ## SYNOPSIS
-Sets a t s step install update
+Sets a TS step install update
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/Set-CMTSStepPartitionDisk.md
+++ b/sccm-ps/ConfigurationManager/Set-CMTSStepPartitionDisk.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # Set-CMTSStepPartitionDisk
 
 ## SYNOPSIS
-Sets a t s step partition disk
+Sets a TS step partition disk
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/Set-CMTSStepReboot.md
+++ b/sccm-ps/ConfigurationManager/Set-CMTSStepReboot.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # Set-CMTSStepReboot
 
 ## SYNOPSIS
-Sets a t s step reboot
+Sets a TS step reboot
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/Set-CMTSStepRunCommandLine.md
+++ b/sccm-ps/ConfigurationManager/Set-CMTSStepRunCommandLine.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # Set-CMTSStepRunCommandLine
 
 ## SYNOPSIS
-Sets a t s step run command line
+Sets a TS step run command line
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/Set-CMTSStepRunPowerShellScript.md
+++ b/sccm-ps/ConfigurationManager/Set-CMTSStepRunPowerShellScript.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # Set-CMTSStepRunPowerShellScript
 
 ## SYNOPSIS
-Sets a t s step run power shell script
+Sets a TS step run power shell script
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/Set-CMTSStepSetVariable.md
+++ b/sccm-ps/ConfigurationManager/Set-CMTSStepSetVariable.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # Set-CMTSStepSetVariable
 
 ## SYNOPSIS
-Sets a t s step set variable
+Sets a TS step set variable
 
 ## SYNTAX
 

--- a/sccm-ps/ConfigurationManager/Set-CMTSStepSetupWindowsAndConfigMgr.md
+++ b/sccm-ps/ConfigurationManager/Set-CMTSStepSetupWindowsAndConfigMgr.md
@@ -7,7 +7,7 @@ schema: 2.0.0
 # Set-CMTSStepSetupWindowsAndConfigMgr
 
 ## SYNOPSIS
-Sets a t s step setup windows and config mgr
+Sets a TS step setup windows and config mgr
 
 ## SYNTAX
 


### PR DESCRIPTION
Referencing a task sequence, we wouldn't use "a t s", it'd be "a TS".  Fixed in all files that had it referenced improperly.  Submission for #MMS2019Docathon