### PR TITLE
Filled in the missing example

### DIFF
--- a/sccm-ps/ConfigurationManager/Get-CMDistributionPointInfo.md
+++ b/sccm-ps/ConfigurationManager/Get-CMDistributionPointInfo.md
@@ -34,7 +34,7 @@ Get-CMDistributionPointInfo [-InputObject <IResultObject>] [-DisableWildcardHand
 
 ### Example 1
 ```
-PS XYZ:\>  
+PS XYZ:\>  Get-CMDistributionPointInfo -SiteSystemServerName "MySiteSys_11310.Contoso.com"
 ```
 
  


### PR DESCRIPTION
There was no example given. This change provides an example.