### PR TITLE
Update Get-CMSiteMaintenanceTask.md

### DIFF
--- a/sccm-ps/ConfigurationManager/Get-CMSiteMaintenanceTask.md
+++ b/sccm-ps/ConfigurationManager/Get-CMSiteMaintenanceTask.md
@@ -43,7 +43,7 @@ A maintenance task is a task in System Center Configuration Manager that perform
 
 ### Example 1: Get a maintenance task
 ```
-PS XYZ:\> Get-CMSiteMaintenanceTask -SiteCode "CM1" -MaintenanceTaskName "Backup"
+PS XYZ:\> Get-CMSiteMaintenanceTask -SiteCode "CM1" -MaintenanceTaskName "Backup SMS Site Server"
 ```
 
 This command gets the maintenance task named Backup for the Configuration Manager site that has the site code CM1.


### PR DESCRIPTION
Get-CMSiteMaintenanceTask -SiteCode "CM1" -MaintenanceTaskName "Backup" doesn't return a value, you need the full Task Name.  Not sure if this changed between versions, but as of 2002 "Backup" doesn't return value, but "Backup SMS Site Server" does.