### PR TITLE
fix syntax error in products taxonomy metadata

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -81,6 +81,7 @@
     "externalReference": [],
     "globalMetadata": {
       "apiPlatform": "powershell",
+      "products": ["https://authoring-docs-microsoft.poolparty.biz/devrel/f1499c3b-793f-48c3-a9ce-20285bcc6541"],
       "breadcrumb_path": "/powershell/sccm/bread/toc.json",
       "feedback_system": "GitHub",
       "feedback_github_repo": "MicrosoftDocs/sccm-docs-powershell-ref",
@@ -102,8 +103,7 @@
       "ms.prod": {
           "**/**.md": "configuration-manager",
           "**/**.yml": "configuration-manager"
-      },
-      "products": ["https://authoring-docs-microsoft.poolparty.biz/devrel/f1499c3b-793f-48c3-a9ce-20285bcc6541"],
+      },      
       "ms.technology": {
           "**/**.md": "configmgr-other",
           "**/**.yml": "configmgr-other"


### PR DESCRIPTION
move products taxonomy config to globalMetadata block