### PR TITLE
Update Set-CMClientSettingEndpointProtection.md

### DIFF
--- a/sccm-ps/ConfigurationManager/Set-CMClientSettingEndpointProtection.md
+++ b/sccm-ps/ConfigurationManager/Set-CMClientSettingEndpointProtection.md
@@ -233,6 +233,9 @@ Accept wildcard characters: False
 ```
 
 ### -RemoveThirdParty
+
+The parameter 'RemoveThirdParty' has been deprecated and may be removed in a future release.
+
 ```yaml
 Type: Boolean
 Parameter Sets: (All)


### PR DESCRIPTION
If you use: "Set-CMClientSettingEndpointProtection -Name XYZ -RemoveThirdParty $True"
You get: WARNING: The parameter 'RemoveThirdParty' has been deprecated and may be removed in a future release.