### PR TITLE
Clarify Get-CMSoftwareUpdateGroup CI_ID Usage

### DIFF
--- a/sccm-ps/ConfigurationManager/Get-CMSoftwareUpdateGroup.md
+++ b/sccm-ps/ConfigurationManager/Get-CMSoftwareUpdateGroup.md
@@ -44,12 +44,12 @@ PS XYZ:\> Get-CMSoftwareUpdateGroup
 
 This command gets all software update groups.
 
-### Example 2: Get a software update group by using an ID
+### Example 2: Get a software update group by using a Config Item ID (CI_ID)
 ```
-PS XYZ:\> Get-CMSoftwareUpdateGroup -Id "ST10000D"
+PS XYZ:\> Get-CMSoftwareUpdateGroup -Id "19060233"
 ```
 
-This command gets a software update group that has the ID ST10000D.
+This command gets a software update group with the Config Item ID "19060233".
 
 ### Example 3: Get a software update group by using a name
 ```
@@ -93,7 +93,7 @@ Accept wildcard characters: False
 ```
 
 ### -Id
-Specifies an array of IDs of software update groups.
+Specifies an array of Config Item IDs (CI_ID) of software update groups.
 
 ```yaml
 Type: Int32[]


### PR DESCRIPTION
## **PR Title:** 
**Clarify Get-CMSoftwareUpdateGroup CI_ID Usage**

## PR status

- [X] This PR is complete and ready for review.

## Description of changes

1. Altered Example 2 to use a more accurate CI_ID (Int32) example, as alphanumeric CM Package IDs aren't allowed.
2. Expanded "ID" language in both the example and the Id parameter description to make it clear the parameter wants the Config Item ID (CI_ID) and not another ID type, such as the CI Unique ID or a CM Package ID.

## More information

Here are some resources that might be helpful while contributing:
- [Microsoft Docs contributor guide](https://docs.microsoft.com/contribute/)
- [Docs Markdown reference](https://docs.microsoft.com/contribute/markdown-reference)
- [Microsoft Writing Style Guide](https://docs.microsoft.com/style-guide/welcome/)
