### PR TITLE
Correct Get-CMApplication -ModelName description & example

### DIFF
--- a/sccm-ps/ConfigurationManager/Get-CMApplication.md
+++ b/sccm-ps/ConfigurationManager/Get-CMApplication.md
@@ -150,7 +150,7 @@ Accept wildcard characters: False
 
 ### -ModelName
 
-Specify the **ModelID** of an application to get. For example, `136846`.
+Specify the **ModelName** of an application to get. For example, `ScopeId_2558247F-19FB-43D4-8FBA-E34809F419D3/Application_1deec342-670d-487f-889f-27fb3662b9d8`.
 
 ```yaml
 Type: String


### PR DESCRIPTION
## PR status

- [x] This PR is complete and ready for review.

## Description of changes

Get-CMApplication's ModelName parameter help currently says it takes a `ModelID` and uses one in the example. It actually takes a `ModelName` (like the parameter name suggests), so correct the parameter's description.

Example of actual usage:
![Screenshot of Get-CMApplication returning 0 results when a ModelID is provided to -ModelName, vs 1 result when a ModelName is used](https://user-images.githubusercontent.com/111144/230778650-a07e3212-aec7-427a-9986-b54f854ebdf0.png)


## Link the PR to an issue

No linked issue