### PR TITLE
Update Set-CMApplication.md

### DIFF
--- a/sccm-ps/ConfigurationManager/Set-CMApplication.md
+++ b/sccm-ps/ConfigurationManager/Set-CMApplication.md
@@ -190,8 +190,6 @@ Accept wildcard characters: False
 
 Specify one or more user category objects to help you filter and find the app group in the console. To get these objects, use the [Get-CMCategory](Get-CMCategory.md) cmdlet. These categories are of type **CatalogCategories**.
 
-To add categories to help users filter and find applications in Software Center, use the **AddAppCategory** parameter.
-
 ```yaml
 Type: IResultObject[]
 Parameter Sets: (All)


### PR DESCRIPTION
**AddAppCategory** points to **AddUserCategory**, but **AddUserCategory** points to **AddUserCategory**. Removed circular reference to AddAppCategory. AddUserCategory is used for filters in Software Center.