### PR TITLE
Enhance Get-CMApplication documentation with hiding app info

### DIFF
--- a/sccm-ps/ConfigurationManager/Get-CMApplication.md
+++ b/sccm-ps/ConfigurationManager/Get-CMApplication.md
@@ -186,11 +186,11 @@ Add this parameter to show hidden applications. A hidden application has the **I
 
 To hide an application, use the following commands:
 
-
-
+```powershell
 $app = Get-CMApplication -Name "test app"
 $app.IsHidden = $true
 $app.Put()
+```
 
 ```yaml
 Type: SwitchParameter
@@ -205,16 +205,19 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
+
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ### Microsoft.ConfigurationManagement.ManagementProvider.IResultObject
+
 ## OUTPUTS
 
-### IResultObject[]#SMS_ApplicationLatest
-### IResultObject#SMS_ApplicationLatest
-### IResultObject#SMS_Application
+### IResultObject\[]\#SMS_ApplicationLatest
+### IResultObject\#SMS_ApplicationLatest
+### IResultObject\#SMS_Application
+
 ## NOTES
 
 For more information on these return object and their properties, see the following articles:


### PR DESCRIPTION

- [X] This PR is complete and ready for review.

## Description of changes

```markdown
**PR Title:** Enhance Get-CMApplication documentation with hiding app info

- Added PowerShell type descriptor
- Added escape character to the Output lines, in order to render the string as (what appears to be) the intended way
```
